### PR TITLE
lab3: dostosowanie do TensorFlow >= 1.5.1

### DIFF
--- a/lab3.ipynb
+++ b/lab3.ipynb
@@ -289,7 +289,7 @@
     "\n",
     "try:\n",
     "    execute_tf_graph(result)\n",
-    "except tf.python.errors.InvalidArgumentError as e:\n",
+    "except tf.errors.InvalidArgumentError as e:\n",
     "    print(e.message)"
    ]
   },


### PR DESCRIPTION
Klikniecie "clear & run all" w VirtualEnv z TF 1.5.1 jak i 1.12 powoduje, ze caly notebook sie wykonuje